### PR TITLE
Setting: Delete duplicate setting of Display cutout

### DIFF
--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -225,12 +225,6 @@
         android:title="@string/proximity_wake_title"
         android:summary="@string/proximity_wake_summary" />
 
-    <ListPreference
-        android:key="display_cutout_emulation"
-		android:layout="@layout/cherish_preference_middle_card"
-        android:title="@string/display_cutout_emulation"
-        settings:keywords="@string/display_cutout_emulation_keywords" />
-
     <SwitchPreference
         android:key="enable_blurs_on_windows"
         android:icon="@drawable/ic_blur"


### PR DESCRIPTION
Delete duplicate setting of Display cutout
Because there is same setting in cherish_settings_statusbar.xml

https://github.com/CherishOS/android_packages_apps_Cherish/blob/2ee9aec4f94/res/xml/cherish_settings_statusbar.xml#L117-L121

Signed-off-by: BrightTwikling <DF.SJbbba5@gmail.com>