### PR TITLE
Settings: Introduce new refresh rate selector page

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1697,6 +1697,26 @@
         </activity>
 
         <activity
+            android:name="Settings$RefreshRateSettingsActivity"
+            android:label="@string/refresh_rate_title"
+            android:exported="true">
+            <intent-filter android:priority="32">
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.android.settings.SHORTCUT" />
+            </intent-filter>
+            <intent-filter android:priority="1">
+                <action android:name="android.settings.REFRESH_RATE_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.display.RefreshRateSettings" />
+            <meta-data android:name="com.android.settings.HIGHLIGHT_MENU_KEY"
+                       android:value="@string/menu_key_display"/>
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+
+        <activity
             android:name="Settings$NightDisplaySuggestionActivity"
             android:enabled="@*android:bool/config_nightDisplayAvailable"
             android:exported="true"

--- a/res/values/vrr_strings.xml
+++ b/res/values/vrr_strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Display settings screen, peak refresh rate settings summary [CHAR LIMIT=NONE] -->
+    <string name="refresh_rate_title">Refresh rate</string>
+    <string name="refresh_rate_summary_vrr_off">%d Hz</string> 
+    <string name="refresh_rate_summary_vrr_on">%d Hz (Adaptive)</string>
+    <string name="refresh_rate_vrr_title">Adaptive refresh rate</string> 
+    <string name="refresh_rate_vrr_summary">Automatically lower the refresh rate when the display is idle, to save power. May cause flickering or color shift on certain displays</string> 
+    <string name="refresh_rate_footer">A higher refresh rate makes the display smoother, but increases power consumption</string>
+    <string name="keywords_refresh_rate">refresh, rate, smooth, peak, 60hz, 90hz, 120hz, 144hz, 165hz</string>
+    <string name="peak_refresh_rate_summary_custom">Automatically raises the refresh rate from 60 to %1$d Hz for some content. Increases battery usage.</string>
+</resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -183,23 +183,13 @@
             android:summary="@string/display_white_balance_summary"
             settings:controller="com.android.settings.display.DisplayWhiteBalancePreferenceController"/>
 
-        <ListPreference
-            android:key="max_refresh_rate"
-            android:title="@string/max_refresh_rate_title"
+        <Preference
+            android:key="refresh_rate"
+            android:title="@string/refresh_rate_title"
             android:summary="@string/summary_placeholder"
-            settings:controller="com.android.settings.display.PeakRefreshRateListPreferenceController" />
-
-        <ListPreference
-            android:key="min_refresh_rate"
-            android:title="@string/min_refresh_rate_title"
-            android:summary="@string/summary_placeholder"
-            settings:controller="com.android.settings.display.MinRefreshRatePreferenceController" />
-
-        <SwitchPreferenceCompat
-            android:key="peak_refresh_rate"
-            android:title="@string/peak_refresh_rate_title"
-            android:summary="@string/peak_refresh_rate_summary"
-            settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
+            android:fragment="com.android.settings.display.RefreshRateSettings"
+            settings:keywords="@string/keywords_refresh_rate"
+            settings:controller="com.android.settings.display.RefreshRatePreferenceController"/>
 
         <SwitchPreferenceCompat
             android:key="show_operator_name"

--- a/res/xml/refresh_rate_settings.xml
+++ b/res/xml/refresh_rate_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2022 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/refresh_rate_title"
+    android:key="refresh_rate"
+    settings:staticPreferenceLocation="append" />

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -115,6 +115,7 @@ public class Settings extends SettingsActivity {
     public static class NightDisplaySettingsActivity extends SettingsActivity { /* empty */ }
     public static class NightDisplaySuggestionActivity extends NightDisplaySettingsActivity { /* empty */ }
     public static class SmartAutoRotateSettingsActivity extends SettingsActivity { /* empty */ }
+    public static class RefreshRateSettingsActivity extends SettingsActivity { /* empty */ }
     public static class MyDeviceInfoActivity extends SettingsActivity { /* empty */ }
     public static class ModuleLicensesActivity extends SettingsActivity { /* empty */ }
     public static class ApplicationSettingsActivity extends SettingsActivity { /* empty */ }

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -112,6 +112,7 @@ import com.android.settings.display.AutoBrightnessSettings;
 import com.android.settings.display.ColorContrastFragment;
 import com.android.settings.display.NightDisplaySettings;
 import com.android.settings.display.ScreenTimeoutSettings;
+import com.android.settings.display.RefreshRateSettings;
 import com.android.settings.display.SmartAutoRotatePreferenceFragment;
 import com.android.settings.display.darkmode.DarkModeSettingsFragment;
 import com.android.settings.dream.DreamSettings;
@@ -363,6 +364,7 @@ public class SettingsGateway {
             MainClearConfirm.class.getName(),
             ResetDashboardFragment.class.getName(),
             NightDisplaySettings.class.getName(),
+            RefreshRateSettings.class.getName(),
             ManageDomainUrls.class.getName(),
             AutomaticStorageManagerSettings.class.getName(),
             StorageDashboardFragment.class.getName(),

--- a/src/com/android/settings/display/RefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/RefreshRatePreferenceController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.PowerManager;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.core.lifecycle.LifecycleObserver;
+import com.android.settingslib.core.lifecycle.events.OnStart;
+import com.android.settingslib.core.lifecycle.events.OnStop;
+
+public class RefreshRatePreferenceController extends BasePreferenceController
+        implements LifecycleObserver, OnStart, OnStop {
+
+    private static final String TAG = "RefreshRatePreferenceController";
+
+    private RefreshRateUtils mUtils;
+    private Preference mPreference;
+    private final PowerManager mPowerManager;
+
+    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (mPreference != null)
+                updateState(mPreference);
+        }
+    };
+
+    public RefreshRatePreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+        mUtils = new RefreshRateUtils(context);
+        mPowerManager = context.getSystemService(PowerManager.class);
+    }
+
+    @Override
+    public void onStart() {
+        mContext.registerReceiver(mReceiver,
+                new IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED));
+    }
+
+    @Override
+    public void onStop() {
+        mContext.unregisterReceiver(mReceiver);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mPreference = screen.findPreference(getPreferenceKey());
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        if (mPowerManager.isPowerSaveMode()) {
+            return mContext.getString(R.string.dark_ui_mode_disabled_summary_dark_theme_on);
+        }
+        return mContext.getString(mUtils.isVrrEnabled() ? R.string.refresh_rate_summary_vrr_on
+                : R.string.refresh_rate_summary_vrr_off, mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mUtils.isHighRefreshRateAvailable() ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        super.updateState(preference);
+        preference.setEnabled(!mPowerManager.isPowerSaveMode());
+    }
+}

--- a/src/com/android/settings/display/RefreshRateSettings.java
+++ b/src/com/android/settings/display/RefreshRateSettings.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreferenceCompat;
+
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settings.widget.RadioButtonPickerFragment;
+import com.android.settingslib.search.SearchIndexable;
+import com.android.settingslib.widget.CandidateInfo;
+import com.android.settingslib.widget.FooterPreference;
+import com.android.settingslib.widget.MainSwitchPreference;
+import com.android.settingslib.widget.SelectorWithWidgetPreference;
+import com.android.settingslib.widget.TopIntroPreference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Preference fragment used for switching refresh rate */
+@SearchIndexable
+public class RefreshRateSettings extends RadioButtonPickerFragment {
+
+    private static final String TAG = "RefreshRateSettings";
+    private static final String KEY_VRR_PREF = "refresh_rate_vrr";
+
+    private Context mContext;
+    private RefreshRateUtils mUtils;
+    private SwitchPreferenceCompat mVrrSwitchPref;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        mContext = context;
+        mUtils = new RefreshRateUtils(context);
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.refresh_rate_settings;
+    }
+
+    @Override
+    protected void addStaticPreferences(PreferenceScreen screen) {
+        mVrrSwitchPref = new SwitchPreferenceCompat(screen.getContext());
+        mVrrSwitchPref.setKey(KEY_VRR_PREF);
+        mVrrSwitchPref.setTitle(R.string.refresh_rate_vrr_title);
+        mVrrSwitchPref.setSummary(R.string.refresh_rate_vrr_summary);
+        mVrrSwitchPref.setOnPreferenceChangeListener((pref, newValue) -> {
+            mUtils.setVrrEnabled((Boolean) newValue);
+            return true;
+        });
+        screen.addPreference(mVrrSwitchPref);
+        updateVrrPref();
+
+        final FooterPreference footerPreference = new FooterPreference(screen.getContext());
+        footerPreference.setTitle(R.string.refresh_rate_footer);
+        footerPreference.setSelectable(false);
+        footerPreference.setLayoutResource(com.android.settingslib.widget.preference.footer.R.layout.preference_footer);
+        screen.addPreference(footerPreference);
+    }
+
+    @Override
+    protected List<? extends CandidateInfo> getCandidates() {
+        return mUtils.getRefreshRates().stream()
+                .filter(r -> r >= RefreshRateUtils.DEFAULT_REFRESH_RATE)
+                .map(RefreshRateCandidateInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    private void updateVrrPref() {
+        if (mVrrSwitchPref == null) return;
+        mVrrSwitchPref.setEnabled(mUtils.isVrrPossible());
+        mVrrSwitchPref.setChecked(mUtils.isVrrEnabled());
+    }
+
+    @Override
+    protected String getDefaultKey() {
+        return String.valueOf(mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    protected boolean setDefaultKey(final String key) {
+        final int refreshRate = Integer.parseInt(key);
+        mUtils.setCurrentRefreshRate(refreshRate);
+        updateVrrPref();
+        return true;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return -1;
+    }
+
+    private class RefreshRateCandidateInfo extends CandidateInfo {
+        private final CharSequence mLabel;
+        private final String mKey;
+
+        RefreshRateCandidateInfo(Integer refreshRate) {
+            super(true);
+            mLabel = String.format("%d Hz", refreshRate.intValue());
+            mKey = refreshRate.toString();
+        }
+
+        @Override
+        public CharSequence loadLabel() {
+            return mLabel;
+        }
+
+        @Override
+        public Drawable loadIcon() {
+            return null;
+        }
+
+        @Override
+        public String getKey() {
+            return mKey;
+        }
+    }
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.refresh_rate_settings) {
+                @Override
+                protected boolean isPageSearchEnabled(Context context) {
+                    return new RefreshRateUtils(context).isHighRefreshRateAvailable();
+                }
+            };
+}

--- a/src/com/android/settings/display/RefreshRateUtils.java
+++ b/src/com/android/settings/display/RefreshRateUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RefreshRateUtils {
+
+    private static final String TAG = "RefreshRateUtils";
+
+    static final int DEFAULT_REFRESH_RATE = 60;
+    static final int DEFAULT_MIN_REFRESH_RATE = 0; // matches fwb. should be 60 though?
+
+    private Context mContext;
+    private List<Integer> mRefreshRates;
+    private int mMinRefreshRate, mMaxRefreshRate;
+
+    RefreshRateUtils(Context context) {
+        mContext = context;
+        mRefreshRates = getRefreshRates();
+        mMinRefreshRate = Collections.min(mRefreshRates);
+        mMaxRefreshRate = Collections.max(mRefreshRates);
+    }
+
+    List<Integer> getRefreshRates() {
+        return Arrays.stream(mContext.getDisplay().getSupportedModes())
+                .map(m -> Math.round(m.getRefreshRate()))
+                .sorted().distinct().collect(Collectors.toList());
+    }
+
+    boolean isHighRefreshRateAvailable() {
+        return mRefreshRates.stream()
+                .filter(r -> r > DEFAULT_REFRESH_RATE)
+                .count() > 0;
+    }
+
+    private int roundToNearestRefreshRate(int refreshRate, boolean floor) {
+        if (mRefreshRates.contains(refreshRate)) return refreshRate;
+        int findRefreshRate = mMinRefreshRate;
+        for (Integer knownRefreshRate : mRefreshRates) {
+            if (!floor) findRefreshRate = knownRefreshRate;
+            if (knownRefreshRate > refreshRate) break;
+            if (floor) findRefreshRate = knownRefreshRate;
+        }
+        return findRefreshRate;
+    }
+
+    private float getDefaultPeakRefreshRate() {
+        return (float) mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_defaultPeakRefreshRate);
+    }
+
+    private int getPeakRefreshRate() {
+        final int peakRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, getDefaultPeakRefreshRate()));
+        return peakRefreshRate < mMinRefreshRate ? mMaxRefreshRate
+                : roundToNearestRefreshRate(peakRefreshRate, true);
+    }
+
+    private void setPeakRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, (float) refreshRate);
+    }
+
+    private int getMinRefreshRate() {
+        final int minRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(), Settings.System.MIN_REFRESH_RATE,
+                (float) DEFAULT_MIN_REFRESH_RATE));
+        return minRefreshRate == DEFAULT_MIN_REFRESH_RATE ? DEFAULT_MIN_REFRESH_RATE
+                : roundToNearestRefreshRate(minRefreshRate, false);
+    }
+
+    private void setMinRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.MIN_REFRESH_RATE, (float) refreshRate);
+    }
+
+    int getCurrentRefreshRate() {
+        return Math.max(getMinRefreshRate(), getPeakRefreshRate());
+    }
+
+    void setCurrentRefreshRate(int refreshRate) {
+        setPeakRefreshRate(refreshRate);
+        setMinRefreshRate(isVrrEnabled() ? DEFAULT_MIN_REFRESH_RATE : refreshRate);
+    }
+
+    boolean isVrrPossible() {
+        return getCurrentRefreshRate() > DEFAULT_REFRESH_RATE;
+    }
+
+    boolean isVrrEnabled() {
+        return getMinRefreshRate() <= DEFAULT_MIN_REFRESH_RATE;
+    }
+
+    void setVrrEnabled(boolean enable) {
+        setMinRefreshRate(enable ? DEFAULT_MIN_REFRESH_RATE : getCurrentRefreshRate());
+    }
+}


### PR DESCRIPTION
On devices that have more than one high refresh rate (eg. 90/120/144 Hz) allow choosing any of those as the peak refresh rate rather than offering only the maximum as a toggle. Use a radio picker preference, similar to screen timeout and display resolution settings. Also add a toggle for VRR that sets the minimum refresh rate.

someone5678: Adapt to U QPR2

Just looks way cleaner and being to able to choose benefits users better especially on pixels

<img width="1344" height="2992" alt="Screenshot_20250903-074454_Only games, videos, and more" src="https://github.com/user-attachments/assets/f424b368-da35-4b62-bfce-b69c5bc4429c" />
